### PR TITLE
Provide access to parameters passed to logging method

### DIFF
--- a/src/ZNetCS.AspNetCore.Logging.EntityFrameworkCore/EntityFrameworkLoggerFactoryExtensions.cs
+++ b/src/ZNetCS.AspNetCore.Logging.EntityFrameworkCore/EntityFrameworkLoggerFactoryExtensions.cs
@@ -44,7 +44,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         public static ILoggerFactory AddEntityFramework<TContext>(
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
-            Func<int, int, string, string, Log> creator = null)
+            Func<int, int, string, string, object[], Log> creator = null)
             where TContext : DbContext
         {
             return AddEntityFramework<TContext>(factory, serviceProvider, LogLevel.Information, creator);
@@ -73,7 +73,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             LogLevel minLevel,
-            Func<int, int, string, string, Log> creator = null)
+            Func<int, int, string, string, object[], Log> creator = null)
             where TContext : DbContext
         {
             return AddEntityFramework<TContext>(factory, serviceProvider, (_, logLevel) => logLevel >= minLevel, creator);
@@ -101,7 +101,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             Func<string, LogLevel, bool> filter,
-            Func<int, int, string, string, Log> creator = null)
+            Func<int, int, string, string, object[], Log> creator = null)
             where TContext : DbContext
         {
             factory.AddProvider(new EntityFrameworkLoggerProvider<TContext>(serviceProvider, filter, creator));
@@ -130,7 +130,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         public static ILoggerFactory AddEntityFramework<TContext, TLog>(
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<int>
         {
@@ -163,7 +163,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             LogLevel minLevel,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<int>
         {
@@ -195,7 +195,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             Func<string, LogLevel, bool> filter,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<int>
         {
@@ -228,7 +228,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         public static ILoggerFactory AddEntityFramework<TContext, TLog, TLogger>(
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<int>
             where TLogger : EntityFrameworkLogger<TContext, TLog>
@@ -265,7 +265,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             LogLevel minLevel,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<int>
             where TLogger : EntityFrameworkLogger<TContext, TLog>
@@ -301,7 +301,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             Func<string, LogLevel, bool> filter,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<int>
             where TLogger : EntityFrameworkLogger<TContext, TLog>
@@ -338,7 +338,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         public static ILoggerFactory AddEntityFramework<TContext, TLog, TLogger, TKey>(
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<TKey>
             where TLogger : EntityFrameworkLogger<TContext, TLog, TKey>
@@ -379,7 +379,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             LogLevel minLevel,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<TKey>
             where TLogger : EntityFrameworkLogger<TContext, TLog, TKey>
@@ -419,7 +419,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this ILoggerFactory factory,
             IServiceProvider serviceProvider,
             Func<string, LogLevel, bool> filter,
-            Func<int, int, string, string, TLog> creator = null)
+            Func<int, int, string, string, object[], TLog> creator = null)
             where TContext : DbContext
             where TLog : Log<TKey>
             where TLogger : EntityFrameworkLogger<TContext, TLog, TKey>

--- a/src/ZNetCS.AspNetCore.Logging.EntityFrameworkCore/EntityFrameworkLoggerProvider.cs
+++ b/src/ZNetCS.AspNetCore.Logging.EntityFrameworkCore/EntityFrameworkLoggerProvider.cs
@@ -43,7 +43,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         /// <param name="creator">
         /// The creator used to create new instance of log.
         /// </param>
-        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, Log> creator = null)
+        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, object[], Log> creator = null)
             : base(serviceProvider, filter, creator)
         {
         }
@@ -79,7 +79,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         /// <param name="creator">
         /// The creator used to create new instance of log.
         /// </param>
-        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, TLog> creator = null)
+        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, object[], TLog> creator = null)
             : base(serviceProvider, filter, creator)
         {
         }
@@ -119,7 +119,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         /// <param name="creator">
         /// The creator used to create new instance of log.
         /// </param>
-        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, TLog> creator = null)
+        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, object[], TLog> creator = null)
             : base(serviceProvider, filter, creator)
         {
         }
@@ -154,7 +154,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         /// <summary>
         /// The function used to create new model instance for a log.
         /// </summary>
-        private readonly Func<int, int, string, string, TLog> creator;
+        private readonly Func<int, int, string, string, object[], TLog> creator;
 
         /// <summary>
         /// The object factory to create new logger used defined types.
@@ -192,7 +192,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
         /// <param name="creator">
         /// The creator used to create new instance of log.
         /// </param>
-        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, TLog> creator = null)
+        public EntityFrameworkLoggerProvider(IServiceProvider serviceProvider, Func<string, LogLevel, bool> filter, Func<int, int, string, string, object[], TLog> creator = null)
         {
             if (serviceProvider == null)
             {
@@ -209,7 +209,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCore
             this.creator = creator;
             this.factory = ActivatorUtilities.CreateFactory(
                 typeof(TLogger),
-                new[] { typeof(string), typeof(Func<string, LogLevel, bool>), typeof(Func<int, int, string, string, TLog>) });
+                new[] { typeof(string), typeof(Func<string, LogLevel, bool>), typeof(Func<int, int, string, string, object[], TLog>) });
         }
 
         #endregion

--- a/test/ZNetCS.AspNetCore.Logging.EntityFrameworkCoreTest/StartupSimpleCreator.cs
+++ b/test/ZNetCS.AspNetCore.Logging.EntityFrameworkCoreTest/StartupSimpleCreator.cs
@@ -61,7 +61,7 @@ namespace ZNetCS.AspNetCore.Logging.EntityFrameworkCoreTest
                     })
                 .AddEntityFramework<ContextSimple>(
                     serviceProvider,
-                    creator: (logLevel, eventId, name, message) => new Log
+                    creator: (logLevel, eventId, name, message, args) => new Log
                     {
                         TimeStamp = DateTimeOffset.Now,
                         Level = logLevel,


### PR DESCRIPTION
Having the ability to include the array of passed parameters will be useful, in addition to the formatted message.  This is structured logging similar to what Serilog provides.  Consider the following:

`log.LogInformation("User created blog post titled '{0}'", blog.Title);`

By using an extended Log model and using the creator delegate, I can save the parameters to a separate text field using character separation, JSON or XML which can then be easily queried/parsed.

It also means that I can include addition parameters that aren't used in the formatted message:

`log.LogInformation("User created blog post titled '{0}'", blog.Title, blog.Tags, blog.Status);`