### PR TITLE
Add .Net Standard 2.0 target.

### DIFF
--- a/src/ZNetCS.AspNetCore.Logging.EntityFrameworkCore/ZNetCS.AspNetCore.Logging.EntityFrameworkCore.csproj
+++ b/src/ZNetCS.AspNetCore.Logging.EntityFrameworkCore/ZNetCS.AspNetCore.Logging.EntityFrameworkCore.csproj
@@ -2,8 +2,12 @@
 
   <PropertyGroup>
     <AssemblyName>ZNetCS.AspNetCore.Logging.EntityFrameworkCore</AssemblyName>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.22"/>
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.22"/>


### PR DESCRIPTION
I haven't tested this explicitly as you are using higher language features in C# than I have and didn't want to revert any unnecessary code.  I'm currently targeting .Net 4.8 but the NetStandard 2.0 should make it available to a number of targets.

Let me know what you think.